### PR TITLE
Fixed a bug where the simulated "ctrl+win+LEFT/RIGHT" gets picked up …

### DIFF
--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -89,14 +89,14 @@ switchDesktopByNumber(targetDesktop)
 
     ; Go right until we reach the desktop we want
     while(CurrentDesktop < targetDesktop) {
-        Send ^#{Right}
+        Send {LWin down}{LCtrl down}{Right down}{LWin up}{LCtrl up}{Right up}
         CurrentDesktop++
         OutputDebug, [right] target: %targetDesktop% current: %CurrentDesktop%
     }
 
     ; Go left until we reach the desktop we want
     while(CurrentDesktop > targetDesktop) {
-        Send ^#{Left}
+        Send {LWin down}{LCtrl down}{Left down}{Lwin up}{LCtrl up}{Left up}
         CurrentDesktop--
         OutputDebug, [left] target: %targetDesktop% current: %CurrentDesktop%
     }


### PR DESCRIPTION
…by certain active programs listening on "win+LEFT/RIGHT", causing them to snap left/right. 2 programs found with such behavior are EmuCon and Clover, both of which run in tabbed mode. 

However, other tabbed programs like Chrome doesn't suffer from this bug; so probably it's just these 2 programs couldn't handle the simulated keystrokes well. 
