### PR TITLE
Fix switcher getting stuck and vastly improve performance

### DIFF
--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -76,6 +76,12 @@ getSessionId()
 switchDesktopByNumber(targetDesktop)
 {
     global CurrentDesktop, DesktopCount
+    
+    ; There are two issues with switching desktops while taskbar is inactive
+    ; 1. Occasionally, due to active windows in intermediary desktops, not all "go right" or "go left" hotkeys are resulting in a switched desktop, this results in switcher getting stuck midway
+    ; 2. Switching is not instantaneous anymore, this introduces rapid flashing (each desktop shows itself for a brief moment)
+    ; Therefore we will activate taskbar
+    WinActivate, ahk_class Shell_TrayWnd
 
     ; Re-generate the list of desktops and where we fit in that. We do this because
     ; the user may have switched desktops via some other means than the script.

--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -77,12 +77,11 @@ switchDesktopByNumber(targetDesktop)
 {
     global CurrentDesktop, DesktopCount
     
-    ; There are three issues with switching desktops while taskbar is inactive (and there are active intermediary windows)
-    ; 1. Occasionally, due to active windows in intermediary desktops, not all "go right" or "go left" hotkeys are resulting in a switched desktop, this results in switcher getting stuck midway (not at the destination desktop, while at the end CurrentDesktop gets itself set to the target desktop number)
+    ; There are three issues with switching desktops with active windows in intermediary desktops:
+    ; 1. Occasionally, not all "go right" or "go left" hotkeys are resulting in a switched desktop, this results in switcher getting stuck midway (not at the destination desktop, while at the end CurrentDesktop gets itself set to the target desktop number)
     ; 2. Switching is not instantaneous anymore, this introduces rapid flashing (each desktop shows itself for a brief moment)
     ; 3. Flashing orange notifications on taskbar on intermediary windows (https://github.com/pmb6tz/windows-desktop-switcher/issues/8)
     ; Therefore we will activate taskbar
-    
     WinActivate, ahk_class Shell_TrayWnd
 
     ; Re-generate the list of desktops and where we fit in that. We do this because

--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -77,10 +77,12 @@ switchDesktopByNumber(targetDesktop)
 {
     global CurrentDesktop, DesktopCount
     
-    ; There are two issues with switching desktops while taskbar is inactive
-    ; 1. Occasionally, due to active windows in intermediary desktops, not all "go right" or "go left" hotkeys are resulting in a switched desktop, this results in switcher getting stuck midway
+    ; There are three issues with switching desktops while taskbar is inactive (and there are active intermediary windows)
+    ; 1. Occasionally, due to active windows in intermediary desktops, not all "go right" or "go left" hotkeys are resulting in a switched desktop, this results in switcher getting stuck midway (not at the destination desktop, while at the end CurrentDesktop gets itself set to the target desktop number)
     ; 2. Switching is not instantaneous anymore, this introduces rapid flashing (each desktop shows itself for a brief moment)
+    ; 3. Flashing orange notifications on taskbar on intermediary windows (https://github.com/pmb6tz/windows-desktop-switcher/issues/8)
     ; Therefore we will activate taskbar
+    
     WinActivate, ahk_class Shell_TrayWnd
 
     ; Re-generate the list of desktops and where we fit in that. We do this because


### PR DESCRIPTION
There are three issues with switching desktops with active windows in intermediary desktops:

1. Occasionally, due to active windows in intermediary desktops, not all "go right" or "go left" hotkeys are resulting in a switched desktop, this results in switcher getting stuck midway (not at the destination desktop, while at the end CurrentDesktop gets itself set to the target desktop number)
2. Switching is not instantaneous anymore, this introduces rapid flashing (each desktop shows itself for a brief moment)
3. Flashing orange notifications on taskbar on intermediary windows (https://github.com/pmb6tz/windows-desktop-switcher/issues/8)

P.S. Refocusing windows after desktop switch is even more useful after this change ([originally appeared here](https://github.com/pmb6tz/windows-desktop-switcher/issues/4)). I've solved it for myself by inserting the dll and cherry-picking the useful parts of the code provided in the [more robust solution](https://github.com/sdias/win-10-virtual-desktop-enhancer) in README (haven't switched to it due to [pmb6tz/windows-desktop-switcher](https://github.com/pmb6tz/windows-desktop-switcher) being much faster and lightweight).