### PR TITLE
Enable cyclic switching, other minor bug and style fixes

### DIFF
--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -84,13 +84,6 @@ getSessionId()
 switchDesktopByNumber(targetDesktop)
 {
     global CurrentDesktop, DesktopCount
-    
-    ; There are three issues with switching desktops with active windows in intermediary desktops:
-    ; 1. Occasionally, not all "go right" or "go left" hotkeys are resulting in a switched desktop, this results in switcher getting stuck midway (not at the destination desktop, while at the end CurrentDesktop gets itself set to the target desktop number)
-    ; 2. Switching is not instantaneous anymore, this introduces rapid flashing (each desktop shows itself for a brief moment)
-    ; 3. Flashing orange notifications on taskbar on intermediary windows (https://github.com/pmb6tz/windows-desktop-switcher/issues/8)
-    ; Therefore we will activate taskbar
-    WinActivate, ahk_class Shell_TrayWnd
 
     ; Re-generate the list of desktops and where we fit in that. We do this because
     ; the user may have switched desktops via some other means than the script.

--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -14,7 +14,8 @@ global IsWindowOnDesktopNumberProc := DllCall("GetProcAddress", Ptr, hVirtualDes
 ; Current desktop UUID appears to be in HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\SessionInfo\1\VirtualDesktops
 ; List of desktops appears to be in HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VirtualDesktops
 ;
-mapDesktopsFromRegistry() {
+mapDesktopsFromRegistry() 
+{
     global CurrentDesktop, DesktopCount
 
     ; Get the current desktop UUID. Length should be 32 always, but there's no guarantee this couldn't change in a later Windows release so we check.
@@ -121,12 +122,14 @@ switchDesktopByNumber(targetDesktop)
     focusTheForemostWindow(targetDesktop)
 }
 
-focusTheForemostWindow(targetDesktop) {
+focusTheForemostWindow(targetDesktop) 
+{
     foremostWindowId := getForemostWindowIdOnDesktop(targetDesktop)
     WinActivate, ahk_id %foremostWindowId%
 }
 
-getForemostWindowIdOnDesktop(n) {
+getForemostWindowIdOnDesktop(n) 
+{
     n := n - 1 ; Desktops start at 0, while in script it's 1
 
     ; winIDList contains a list of windows IDs ordered from the top to the bottom for each desktop.


### PR DESCRIPTION
There is an issue with the current implementation of Switch to Next/Previous desktop, because it doesn't call `mapDesktopsFromRegistry` before getting the value of `CurrentDesktop`.

I've fixed this and some other bugs, also enabled cyclic switching when using `Capslock` `a`/`s`.