### PR TITLE
Add ability to move windows to other desktops

### DIFF
--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -1,6 +1,8 @@
 #SingleInstance Force ; The script will Reload if launched while already running
-#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
-SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
+#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases
+#KeyHistory 0 ; Ensures user privacy when debugging is not needed
+SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory
+SendMode Input  ; Recommended for new scripts due to its superior speed and reliability
 
 ; Globals
 DesktopCount := 2        ; Windows starts with 2 desktops at boot

--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -155,7 +155,7 @@ getSessionId()
 
 _switchDesktopToTarget(targetDesktop)
 {
-	; Globals variables should have been updated via updateGlobalVariables() prior to entering this function
+    ; Globals variables should have been updated via updateGlobalVariables() prior to entering this function
     global CurrentDesktop, DesktopCount, LastOpenedDesktop
 
     ; Don't attempt to switch to an invalid desktop
@@ -166,7 +166,7 @@ _switchDesktopToTarget(targetDesktop)
 
     LastOpenedDesktop := CurrentDesktop
 
-	; Fixes the issue of active windows in intermediate desktops capturing the switch shortcut and therefore delaying or stopping the switching sequence. This also fixes the flashing window button after switching in the taskbar. More info: https://github.com/pmb6tz/windows-desktop-switcher/pull/19
+    ; Fixes the issue of active windows in intermediate desktops capturing the switch shortcut and therefore delaying or stopping the switching sequence. This also fixes the flashing window button after switching in the taskbar. More info: https://github.com/pmb6tz/windows-desktop-switcher/pull/19
     WinActivate, ahk_class Shell_TrayWnd
 
     ; Go right until we reach the desktop we want
@@ -183,7 +183,7 @@ _switchDesktopToTarget(targetDesktop)
         OutputDebug, [left] target: %targetDesktop% current: %CurrentDesktop%
     }
 
-	; Makes the WinActivate fix less intrusive
+    ; Makes the WinActivate fix less intrusive
     Sleep, 50
     focusTheForemostWindow(targetDesktop)
 }
@@ -198,7 +198,7 @@ updateGlobalVariables()
 switchDesktopByNumber(targetDesktop)
 {
     global CurrentDesktop, DesktopCount
-	updateGlobalVariables()
+    updateGlobalVariables()
     _switchDesktopToTarget(targetDesktop)
 }
 
@@ -246,9 +246,9 @@ getForemostWindowIdOnDesktop(n)
 }
 
 MoveCurrentWindowToDesktop(desktopNumber) {
-	WinGet, activeHwnd, ID, A
-	DllCall(MoveWindowToDesktopNumberProc, UInt, activeHwnd, UInt, desktopNumber - 1)
-	switchDesktopByNumber(desktopNumber)
+    WinGet, activeHwnd, ID, A
+    DllCall(MoveWindowToDesktopNumberProc, UInt, activeHwnd, UInt, desktopNumber - 1)
+    switchDesktopByNumber(desktopNumber)
 }
 
 ;

--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -1,3 +1,4 @@
+#SingleInstance Force ; The script will Reload if launched while already running
 #NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
 SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
 
@@ -16,73 +17,8 @@ SetKeyDelay, 75
 mapDesktopsFromRegistry()
 OutputDebug, [loading] desktops: %DesktopCount% current: %CurrentDesktop%
 
-; ================================
-; ====== User configuration ======
-; ================================
-; This section binds the key combo to the switch/create/delete actions
-CapsLock & 1::switchDesktopByNumber(1)
-CapsLock & 2::switchDesktopByNumber(2)
-CapsLock & 3::switchDesktopByNumber(3)
-CapsLock & 4::switchDesktopByNumber(4)
-CapsLock & 5::switchDesktopByNumber(5)
-CapsLock & 6::switchDesktopByNumber(6)
-CapsLock & 7::switchDesktopByNumber(7)
-CapsLock & 8::switchDesktopByNumber(8)
-CapsLock & 9::switchDesktopByNumber(9)
-
-CapsLock & n::switchDesktopToRight()
-CapsLock & p::switchDesktopToLeft()
-CapsLock & s::switchDesktopToRight()
-CapsLock & a::switchDesktopToLeft()
-CapsLock & tab::switchDesktopToLastOpened()
-
-CapsLock & c::createVirtualDesktop()
-CapsLock & d::deleteVirtualDesktop()
-
-CapsLock & q::MoveCurrentWindowToDesktop(1)
-CapsLock & w::MoveCurrentWindowToDesktop(2)
-CapsLock & e::MoveCurrentWindowToDesktop(3)
-CapsLock & r::MoveCurrentWindowToDesktop(4)
-CapsLock & t::MoveCurrentWindowToDesktop(5)
-CapsLock & y::MoveCurrentWindowToDesktop(6)
-CapsLock & u::MoveCurrentWindowToDesktop(7)
-CapsLock & i::MoveCurrentWindowToDesktop(8)
-CapsLock & o::MoveCurrentWindowToDesktop(9)
-
-
-; Alternate keys for this config. Adding these because DragonFly (python) doesn't send CapsLock correctly.
-^!1::switchDesktopByNumber(1)
-^!2::switchDesktopByNumber(2)
-^!3::switchDesktopByNumber(3)
-^!4::switchDesktopByNumber(4)
-^!5::switchDesktopByNumber(5)
-^!6::switchDesktopByNumber(6)
-^!7::switchDesktopByNumber(7)
-^!8::switchDesktopByNumber(8)
-^!9::switchDesktopByNumber(9)
-
-^!n::switchDesktopToRight()
-^!p::switchDesktopToLeft()
-^!s::switchDesktopToRight()
-^!a::switchDesktopToLeft()
-^!tab::switchDesktopToLastOpened()
-
-^!c::createVirtualDesktop()
-^!d::deleteVirtualDesktop()
-
-^#1::MoveCurrentWindowToDesktop(1)
-^#2::MoveCurrentWindowToDesktop(2)
-^#3::MoveCurrentWindowToDesktop(3)
-^#4::MoveCurrentWindowToDesktop(4)
-^#5::MoveCurrentWindowToDesktop(5)
-^#6::MoveCurrentWindowToDesktop(6)
-^#7::MoveCurrentWindowToDesktop(7)
-^#8::MoveCurrentWindowToDesktop(8)
-^#9::MoveCurrentWindowToDesktop(9)
-
-; =======================================
-; ====== End of user configuration ======
-; =======================================
+#Include user_config.ahk
+return
 
 ;
 ; This function examines the registry to build an accurate list of the current virtual desktops and which one we're currently on.

--- a/user_config.ahk
+++ b/user_config.ahk
@@ -1,0 +1,85 @@
+; ====================
+; === INSTRUCTIONS ===
+; ====================
+; 1. Any lines starting with ; are ignored
+; 2. After changing this config file run script file "desktop_switcher.ahk"
+; 3. Every line is in the format HOTKEY::ACTION
+
+; === SYMBOLS ===
+; !   <- Alt
+; +   <- Shift
+; ^   <- Ctrl
+; #   <- Win
+; For more, visit https://autohotkey.com/docs/Hotkeys.htm
+
+; === EXAMPLES ===
+; !n::switchDesktopToRight()             <- <Alt> + <N> will switch to the next desktop (to the right of the current one)
+; #!space::switchDesktopToRight()        <- <Win> + <Alt> + <Space> will switch to next desktop
+; CapsLock & n::switchDesktopToRight()   <- <CapsLock> + <N> will switch to the next desktop (& is necessary when using non-modifier key such as CapsLock)
+
+; ===========================
+; === END OF INSTRUCTIONS ===
+; ===========================
+
+CapsLock & 1::switchDesktopByNumber(1)
+CapsLock & 2::switchDesktopByNumber(2)
+CapsLock & 3::switchDesktopByNumber(3)
+CapsLock & 4::switchDesktopByNumber(4)
+CapsLock & 5::switchDesktopByNumber(5)
+CapsLock & 6::switchDesktopByNumber(6)
+CapsLock & 7::switchDesktopByNumber(7)
+CapsLock & 8::switchDesktopByNumber(8)
+CapsLock & 9::switchDesktopByNumber(9)
+
+CapsLock & n::switchDesktopToRight()
+CapsLock & p::switchDesktopToLeft()
+CapsLock & s::switchDesktopToRight()
+CapsLock & a::switchDesktopToLeft()
+CapsLock & tab::switchDesktopToLastOpened()
+
+CapsLock & c::createVirtualDesktop()
+CapsLock & d::deleteVirtualDesktop()
+
+CapsLock & q::MoveCurrentWindowToDesktop(1)
+CapsLock & w::MoveCurrentWindowToDesktop(2)
+CapsLock & e::MoveCurrentWindowToDesktop(3)
+CapsLock & r::MoveCurrentWindowToDesktop(4)
+CapsLock & t::MoveCurrentWindowToDesktop(5)
+CapsLock & y::MoveCurrentWindowToDesktop(6)
+CapsLock & u::MoveCurrentWindowToDesktop(7)
+CapsLock & i::MoveCurrentWindowToDesktop(8)
+CapsLock & o::MoveCurrentWindowToDesktop(9)
+
+; === INSTRUCTIONS ===
+; Below is the alternate key configuration. Delete symbol ; in the beginning of the line to enable. 
+; Note, that  ^!1  means "Ctrl + Alt + 1" and  ^#1  means "Ctrl + Win + 1"
+; === END OF INSTRUCTIONS ===
+
+; ^!1::switchDesktopByNumber(1)
+; ^!2::switchDesktopByNumber(2)
+; ^!3::switchDesktopByNumber(3)
+; ^!4::switchDesktopByNumber(4)
+; ^!5::switchDesktopByNumber(5)
+; ^!6::switchDesktopByNumber(6)
+; ^!7::switchDesktopByNumber(7)
+; ^!8::switchDesktopByNumber(8)
+; ^!9::switchDesktopByNumber(9)
+
+; ^!n::switchDesktopToRight()
+; ^!p::switchDesktopToLeft()
+; ^!s::switchDesktopToRight()
+; ^!a::switchDesktopToLeft()
+; ^!tab::switchDesktopToLastOpened()
+
+; ^!c::createVirtualDesktop()
+; ^!d::deleteVirtualDesktop()
+
+; ^#1::MoveCurrentWindowToDesktop(1)
+; ^#2::MoveCurrentWindowToDesktop(2)
+; ^#3::MoveCurrentWindowToDesktop(3)
+; ^#4::MoveCurrentWindowToDesktop(4)
+; ^#5::MoveCurrentWindowToDesktop(5)
+; ^#6::MoveCurrentWindowToDesktop(6)
+; ^#7::MoveCurrentWindowToDesktop(7)
+; ^#8::MoveCurrentWindowToDesktop(8)
+; ^#9::MoveCurrentWindowToDesktop(9)


### PR DESCRIPTION
Features added:
1. Moving of windows to other desktops (feel free to change hotkeys to ones you prefer without my input)

Other code changes made:
1. Moving of user configuration to the top. All text editors will open the script at the top, why force our users scroll to the bottom :)
2. Don't do actions if switching to the desktop we're already in. IMO, it's more robust this way (otherwise we will focus/defocus windows needlessly)
3. Rearranged `switchDesktopByNumber(targetDesktop)` and its sibling functions to make them more palatable (previously, the same comment was repeated multiple times. Also made `mapDesktopsFromRegistry()` relationship to the global variables clearer)
