### PR TITLE
Add script dir prefix to config file import path

### DIFF
--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -19,7 +19,7 @@ SetKeyDelay, 75
 mapDesktopsFromRegistry()
 OutputDebug, [loading] desktops: %DesktopCount% current: %CurrentDesktop%
 
-#Include user_config.ahk
+#Include %A_ScriptDir%\user_config.ahk
 return
 
 ;


### PR DESCRIPTION
When running the script on boot via Task Scheduler, `#Include user_config.ahk` returns an error indicating the file could not be opened. Running the script on boot via Task Scheduler is likely changing the working directory where `#Include` searches for the file to import. Additionally, `SetWorkingDir %A_ScriptDir%` does not fix it since `#Include`s are processed before a script executes.