### PR TITLE
only activate window if not minimized

### DIFF
--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -164,7 +164,10 @@ switchDesktopToLeft()
 focusTheForemostWindow(targetDesktop) 
 {
     foremostWindowId := getForemostWindowIdOnDesktop(targetDesktop)
-    WinActivate, ahk_id %foremostWindowId%
+    WinGet MMX, MinMax, ahk_id %foremostWindowId%
+    If (MMX != -1) {
+        WinActivate, ahk_id %foremostWindowId%
+    }
 }
 
 getForemostWindowIdOnDesktop(n)

--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -161,13 +161,16 @@ switchDesktopToLeft()
     _switchDesktopToTarget(CurrentDesktop == 1 ? DesktopCount : CurrentDesktop - 1)
 }
 
-focusTheForemostWindow(targetDesktop) 
-{
+focusTheForemostWindow(targetDesktop) {
     foremostWindowId := getForemostWindowIdOnDesktop(targetDesktop)
-    WinGet MMX, MinMax, ahk_id %foremostWindowId%
-    If (MMX != -1) {
+    if isWindowNonMinimized(foremostWindowId) {
         WinActivate, ahk_id %foremostWindowId%
     }
+}
+
+isWindowNonMinimized(windowId) {
+    WinGet MMX, MinMax, ahk_id %windowId%
+    return MMX != -1
 }
 
 getForemostWindowIdOnDesktop(n)


### PR DESCRIPTION
When I switch to a desktop with minimized windows only they should not get activated (imho). This patch checks the windows state and only activates it if not minimized.