### PR TITLE
fix: Add AHK Version Requirement

### DIFF
--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -1,3 +1,4 @@
+#Requires AutoHotkey v1.1.33+
 #SingleInstance Force ; The script will Reload if launched while already running
 #NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases
 #KeyHistory 0 ; Ensures user privacy when debugging is not needed


### PR DESCRIPTION
Adds a `#Requires` directive (https://www.autohotkey.com/docs/v1/lib/_Requires.htm) to the beginning of the script so that AHK Version 2 knows to run this with the v1 interpreter.

Preferably, this whole script should be refactored to support V2, but this provides immediate support on the V2 engine (via AHK's automatic engine switcher) for users who are brand new to AHK (such as myself)

Closes #86