### PR TITLE
Revise README for window animation settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can also customize the hotkeys and actions as described in the section below
 This script creates more convenient hotkeys for switching virtual desktops in Windows 10. I built this to better mirror the mapping I use on linux (with dwm), and it's always annoyed me that Windows does not have better hotkey support for this feature (for instance, there's no way to go directly to a desktop by number).
 
 ## Running
-[Install AutoHotkey v1.1](https://autohotkey.com/download/1.1/AutoHotkey_1.1.37.02_setup.exe) (v2 is [not supported](https://github.com/pmb6tz/windows-desktop-switcher/issues/93) at this time), then run the `desktop_switcher.ahk` script (open with AutoHotkey if prompted). You can disable the switching animation by opening "Adjust the appearance and performance of Windows" and then unselecting the checkmark "Animate windows when minimizing and maximizing".
+[Install AutoHotkey v1.1](https://autohotkey.com/download/1.1/AutoHotkey_1.1.37.02_setup.exe) (v2 is [not supported](https://github.com/pmb6tz/windows-desktop-switcher/issues/93) at this time), then run the `desktop_switcher.ahk` script (open with AutoHotkey if prompted). You can disable the switching animation by opening "Adjust the appearance and performance of Windows" and then unselecting the checkmark "Animate controls and elements inside windows".
 
 ### Notes about Windows 1809/1903≤ Updates
 This project relies partly on [VirtualDesktopAccessor.dll](https://github.com/Ciantic/VirtualDesktopAccessor) (for moving windows to other desktops). This binary is included in this repository for convenience, and was recently updated to work with the 1809/1903≤ updates. 


### PR DESCRIPTION
Updated instructions for disabling window animations in the README.

The previous instructions of unchecking "Animate windows when minimizing and maximizing" did not remove the desktop switch animation.

Instead, I had to uncheck "Animate controls and elements inside windows" to remove the animation.